### PR TITLE
Simple fixes on shared_ptr for better performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 
 project(TG_SayStickerBot)
 

--- a/src/MakeSticker.cpp
+++ b/src/MakeSticker.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <memory>
 
 #include "Log.h"
 #include "Global.h"
@@ -13,7 +14,7 @@ using namespace cv;
 using namespace TgBot;
 
 // ArtRobot的实际绘制函数
-std::tuple<shared_ptr<ArtRobot::Component::Base>, double, double>
+std::tuple<unique_ptr<ArtRobot::Component::Base>, double, double>
 drawImage(const string &__userPhotoData, const string &__name, const string &__content)
 {
     // 首先创建文字，因为需要计算其中宽高
@@ -45,7 +46,7 @@ drawImage(const string &__userPhotoData, const string &__name, const string &__c
 
     cout << ws << " " << hs << endl;
 
-    auto body = make_shared<ArtRobot::Component::Group>("body"); // body
+    auto body = make_unique<ArtRobot::Component::Group>("body"); // body
 
     auto bg = make_shared<ArtRobot::Component::Rectangle>("bg", 0, 0, 512 - ws, 512 - hs, 0, "79B3E2"); // bg
     body->addChild(bg);
@@ -87,7 +88,7 @@ drawImage(const string &__userPhotoData, const string &__name, const string &__c
     double realWidth = 512 - ws,
            realHeight = 512 - hs;
 
-    return {body, realWidth, realHeight};
+    return {move(body), realWidth, realHeight};
 }
 
 string MakeSticker(const Api &api, int64_t chatId,


### PR DESCRIPTION
According to the bug reports of my smart pointer analysis tool, you have a 'unique shared_ptr' problem in file `src/MakeSticker.cpp`. As the `shared_ptr` uses more resources than the `unique_ptr`, if the ownership is not semantically shared among multiple `shared_ptr`s, the `unique_ptr` is preferred for better performances.

This patch fixes the problem by replacing the corresponding `shared_ptr` with `unique_ptr` and using `std::make_unique` and `std::move` to create and transfer the `unique_ptr` respectively. As the function `std::make_unique` and structured bindings (used in your original code) were introduced in C++14 and C++17 respectively, I also changed the C++ standard to C++17.

The uniquely used shared_ptr (`body`) and the usage of structured bindings:
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L161

The simplified path reported in the bug report:

1. Start analysis:
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L93

1. Calling `drawImage`
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L161

1. Enter function `drawImage`
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L17

1. Calling `make_shared<ArtRobot::Component::Group, char const (&)[5]>`
1. Allocate memory object: [Newed] `HeapSymRegion{conj_$154{class ArtRobot::Component::Group *, LC71, S18707732, #1}}`
1. Memory object assigned: `class std::shared_ptr<class ArtRobot::Component::Group> body = HeapSymRegion{conj_$154{class ArtRobot::Component::Group *, LC71, S18707732, #1}}` (use count: 1 | weak count: 0)
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L48

1. Calling constructor for `tuple<std::shared_ptr<ArtRobot::Component::Base>, double, double>`
1. Memory object assigned: `class std::shared_ptr<class ArtRobot::Component::Base> Base{Base{temp_object{std::tuple<shared_ptr<ArtRobot::Component::Base>, double, double>, S15908058},_Tuple_impl},_Head_base}->_M_head_impl = HeapSymRegion{conj_$154{class ArtRobot::Component::Group *, LC71, S18707732, #1}}` (use count: 2 | weak count: 0)
1. Memory object dis-assigned: `HeapSymRegion{conj_$154{class ArtRobot::Component::Group *, LC71, S18707732, #1}}` (use count: 1 | weak count: 0)
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L90

1. Returning from 'drawImage'
1. Memory object moved: `class std::shared_ptr<class ArtRobot::Component::Base> body = HeapSymRegion{conj_$154{class ArtRobot::Component::Group *, LC71, S18707732, #1}}` (use count: 1 | weak count: 0) **(the unique owner pointer assigned)**
https://github.com/YJBeetle/SayStickerBot/blob/0cd2f33faf72b11302cd6be2903e2e1dde2942e9/src/MakeSticker.cpp#L161

1. Function exits.

After the `body` assigned on line 161, its ownership is no shared with any other `shared_ptr`s. Therefore, it is seen as a unique shared_ptr, which has better be replaced with `unique_ptr` or a local variable object. In this patch, I chose the former.